### PR TITLE
66 refactor api calls and make url configurable

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -52,6 +52,11 @@ export default {
     ...endpoint('/recipes'),
     ingredients: {
       get: (id) => fetch(`${BASE}/recipes/${id}/ingredients`).then(d => d.json()),
+      add: (recipe_id, data) => fetch(`${BASE}/recipes/${recipe_id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      }).then(d => d.json())
     },
     comments: {
       get: (id) => fetch(`${BASE}/recipes/${id}/comments`).then(d => d.json()),

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,53 @@
+
+const BASE = 'http://127.0.0.1:8000'
+
+const endpoint = (path) => {
+  const URL = BASE + '/' + path;
+
+  const getAll = async () => {
+    const response = await fetch(URL)
+    return response.json()
+  }
+
+  const get = async (id) => {
+    const response = await fetch(URL + '/' + id)
+    return response.json()
+  }
+
+  const create = async (data) => {
+    const response = await fetch(URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    return response.json()
+  }
+
+  const update = async (id, data) => {
+    const response = await fetch(URL, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    return response.json()
+  }
+
+  const remove = async (id) => {
+    const response = await fetch(URL + '/' + id, {
+      method: 'DELETE',
+    })
+    return response.json()
+  }
+
+  return {
+    getAll,
+    get,
+    create,
+    update,
+    remove,
+  }
+}
+
+export default {
+  recipes: endpoint('recipes'),
+}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,7 +1,7 @@
 const BASE = 'http://127.0.0.1:8000'
 
 const endpoint = (path) => {
-  const URL = BASE + '/' + path;
+  const URL = BASE + path;
 
   const getAll = async () => {
     const response = await fetch(URL)
@@ -48,5 +48,13 @@ const endpoint = (path) => {
 }
 
 export default {
-  recipes: endpoint('recipes'),
+  recipes: {
+    ...endpoint('/recipes'),
+    ingredients: {
+      get: (id) => fetch(`${BASE}/recipes/${id}/ingredients`),
+    },
+    comments: {
+      get: (id) => fetch(`${BASE}/recipes/${id}/comments`),
+    }
+  },
 }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -62,4 +62,5 @@ export default {
       get: (id) => fetch(`${BASE}/recipes/${id}/comments`).then(d => d.json()),
     }
   },
+  ingredients: endpoint('/ingredients'),
 }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -86,4 +86,6 @@ export default {
         body: JSON.stringify(data),
       }),
   },
+  mealplans: endpoint('/mealplans'),
+  comments: endpoint('/comments'),
 }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,4 +1,3 @@
-
 const BASE = 'http://127.0.0.1:8000'
 
 const endpoint = (path) => {
@@ -24,7 +23,7 @@ const endpoint = (path) => {
   }
 
   const update = async (id, data) => {
-    const response = await fetch(URL, {
+    const response = await fetch(URL + '/' + id, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -65,7 +65,7 @@ export default {
   ingredients: endpoint('/ingredients'),
   recipe_ingredients: {
     ...endpoint('/recipe_ingredients'),
-    put: (recipe_id, ingredient_id, data) =>
+    update: (recipe_id, ingredient_id, data) =>
       fetch(`${BASE}/recipe_ingredients/${recipe_id}:${ingredient_id}`, {
         method: 'PUT',
         headers: {
@@ -73,11 +73,11 @@ export default {
         },
         body: JSON.stringify(data),
       }).then((r) => r.json()),
-    delete: (recipe_id, ingredient_id) =>
+    remove: (recipe_id, ingredient_id) =>
       fetch(`${BASE}/recipe_ingredients/${recipe_id}:${ingredient_id}`, {
         method: 'DELETE',
       }).then((r) => r.json()),
-    put_many: (data) =>
+    udpate_many: (data) =>
       fetch(`${BASE}/recipe_ingredients/bulk`, {
         method: 'PUT',
         headers: {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -52,7 +52,7 @@ export default {
     ...endpoint('/recipes'),
     ingredients: {
       get: (id) => fetch(`${BASE}/recipes/${id}/ingredients`).then(d => d.json()),
-      add: (recipe_id, data) => fetch(`${BASE}/recipes/${recipe_id}`, {
+      add: (recipe_id, data) => fetch(`${BASE}/recipes/${recipe_id}/ingredients`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -19,7 +19,8 @@ const endpoint = (path) => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
     })
-    return response.json()
+    const result = await response.json()
+    return result
   }
 
   const update = async (id, data) => {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,4 +1,6 @@
-const BASE = 'http://127.0.0.1:8000'
+import { env } from '$env/dynamic/public'
+
+const BASE = env.PUBLIC_APIURL
 
 const endpoint = (path) => {
   const URL = BASE + path;

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -63,4 +63,27 @@ export default {
     }
   },
   ingredients: endpoint('/ingredients'),
+  recipe_ingredients: {
+    ...endpoint('/recipe_ingredients'),
+    put: (recipe_id, ingredient_id, data) =>
+      fetch(`${BASE}/recipe_ingredients/${recipe_id}:${ingredient_id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      }).then((r) => r.json()),
+    delete: (recipe_id, ingredient_id) =>
+      fetch(`${BASE}/recipe_ingredients/${recipe_id}:${ingredient_id}`, {
+        method: 'DELETE',
+      }).then((r) => r.json()),
+    put_many: (data) =>
+      fetch(`${BASE}/recipe_ingredients/bulk`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      }),
+  },
 }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -77,7 +77,7 @@ export default {
       fetch(`${BASE}/recipe_ingredients/${recipe_id}:${ingredient_id}`, {
         method: 'DELETE',
       }).then((r) => r.json()),
-    udpate_many: (data) =>
+    update_many: (data) =>
       fetch(`${BASE}/recipe_ingredients/bulk`, {
         method: 'PUT',
         headers: {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -51,10 +51,10 @@ export default {
   recipes: {
     ...endpoint('/recipes'),
     ingredients: {
-      get: (id) => fetch(`${BASE}/recipes/${id}/ingredients`),
+      get: (id) => fetch(`${BASE}/recipes/${id}/ingredients`).then(d => d.json()),
     },
     comments: {
-      get: (id) => fetch(`${BASE}/recipes/${id}/comments`),
+      get: (id) => fetch(`${BASE}/recipes/${id}/comments`).then(d => d.json()),
     }
   },
 }

--- a/frontend/src/lib/stores/ingredients.js
+++ b/frontend/src/lib/stores/ingredients.js
@@ -1,26 +1,15 @@
+import api from '$lib/api'
 import { writable } from 'svelte/store';
-
-const BASE = 'http://127.0.0.1:8000/ingredients';
 
 const initIngredients = () => {
   const { subscribe, set, update } = writable([]);
 
-  fetch(BASE)
-    .then((response) => response.json())
-    .then((data) => set(data));
+  api.ingredients.getAll().then(data => set(data))
 
-  const add = async (data) => {
-    const response = await fetch(BASE, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
-
-    const ingredient = await response.json();
-    update((state) => [...state, ingredient]);
-
-    return ingredient;
-  };
+  const add = async (data) => api.ingredients.create(data).then(d => {
+    update(state => [...state, d])
+    return d
+  })
 
   return {
     subscribe,

--- a/frontend/src/lib/stores/recipes.js
+++ b/frontend/src/lib/stores/recipes.js
@@ -6,10 +6,12 @@ const initRecipes = () => {
 
   api.recipes.getAll().then(data => set(data));
 
-  const create = (data) => api.recipes.create(data).then(d => update(s => {
-    [...s, d]
-    return d
-  }))
+  const create = async (data) => {
+    const result = await api.recipes.create(data)
+    update(s => [...s, result])
+    return result
+  }
+
   const edit = (id, data) => api.recipes
     .update(id, data)
     .then(data => update(state => state.map(s => s.id === data.id ? data : s)))

--- a/frontend/src/lib/stores/recipes.js
+++ b/frontend/src/lib/stores/recipes.js
@@ -6,7 +6,10 @@ const initRecipes = () => {
 
   api.recipes.getAll().then(data => set(data));
 
-  const create = (data) => api.recipes.create(data).then(d => update(s => [...s, d]))
+  const create = (data) => api.recipes.create(data).then(d => update(s => {
+    [...s, d]
+    return d
+  }))
   const edit = (id, data) => api.recipes
     .update(id, data)
     .then(data => update(state => state.map(s => s.id === data.id ? data : s)))

--- a/frontend/src/lib/stores/recipes.js
+++ b/frontend/src/lib/stores/recipes.js
@@ -1,48 +1,25 @@
 import { writable } from 'svelte/store';
-
-const BASE = 'http://127.0.0.1:8000/recipes';
+import api from '$lib/api'
 
 const initRecipes = () => {
   const { subscribe, set, update } = writable([]);
 
-  fetch(BASE)
-    .then((response) => response.json())
-    .then((data) => set(data));
+  api.recipes.getAll().then(data => set(data));
 
-  const add = async (data) => {
-    const response = await fetch(BASE, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
+  const create = (data) => api.recipes.create(data).then(d => update(s => [...s, d]))
+  const edit = (id, data) => api.recipes
+    .update(id, data)
+    .then(data => update(state => state.map(s => s.id === data.id ? data : s)))
 
-    const recipe = await response.json();
-
-    update((state) => [...state, recipe]);
-
-    return recipe;
-  };
-
-  const edit = async (id, data) => {
-    const response = await fetch(BASE + `/${id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
-    });
-
-    const recipe = await response.json();
-
-    update((state) => state.map((r) => (r.id === id ? recipe : r)));
-
-    return recipe;
-  };
+  const remove = (id) => api.recipes.remove(id).then(data => update(state => state.filter(s => s.id !== data.id)))
 
   return {
     subscribe,
     set,
     update,
-    add,
+    create,
     edit,
+    remove,
   };
 };
 

--- a/frontend/src/routes/mealplan/+page.js
+++ b/frontend/src/routes/mealplan/+page.js
@@ -1,5 +1,7 @@
+import api from '$lib/api'
+
 export async function load({ fetch }) {
   return {
-    mealplans: (await fetch('http://127.0.0.1:8000/mealplans')).json(),
+    mealplans: await api.mealplans.getAll(),
   };
 }

--- a/frontend/src/routes/mealplan/+page.svelte
+++ b/frontend/src/routes/mealplan/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import api from '$lib/api'
   import MealCard from './MealCard.svelte';
   export let data;
 
@@ -45,16 +46,6 @@
       .filter((mp) => !hidedone || mp.state !== 'done'),
   );
 
-  const postMealplan = (data) => {
-    return fetch('http://127.0.0.1:8000/mealplans', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(data),
-    });
-  };
-
   const create = () => {
     // create lunch and dinner for two for each date
     for (var d = new Date(create_start); d <= new Date(create_end); d.setDate(d.getDate() + 1)) {
@@ -65,10 +56,9 @@
       };
 
       Promise.all([
-        postMealplan({ ...base, name: 'lunch', position: 1 }),
-        postMealplan({ ...base, name: 'dinner', position: 2 }),
+        api.mealplans.create({ ...base, name: 'lunch', position: 1 }),
+        api.mealplans.create({ ...base, name: 'dinner', position: 2 }),
       ])
-        .then((arr) => Promise.all(arr.map((r) => r.json())))
         .then((d) => (data.mealplans = [...data.mealplans, ...d]));
     }
 

--- a/frontend/src/routes/mealplan/MealCard.svelte
+++ b/frontend/src/routes/mealplan/MealCard.svelte
@@ -1,31 +1,21 @@
 <script>
+  import api from '$lib/api'
   import recipes from '$lib/stores/recipes';
   export let date;
   export let meals;
 
   let node;
 
-  const save = () => {
-    meals.forEach((meal) => {
-      fetch(`http://127.0.0.1:8000/mealplans/${meal.id}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(meal),
-      }).then((r) => r.json());
-    });
-  };
+  const save = () => meals.forEach((meal) => api.mealplans.update(meal.id, meal))
 
   const remove = (meal) => {
-    fetch(`http://127.0.0.1:8000/mealplans/${meal.id}`, { method: 'DELETE' })
-      .then((r) => r.json())
-      .then((data) => {
+    api.mealplans.remove(meal.id)
+      .then(data => {
         meals = meals.filter((m) => m.id != meal.id);
-
+    
         // remove container if no meals - could probably be done smoother through a store
         if (!meals.length) node.parentNode.removeChild(node);
-      });
+      })
   };
 </script>
 

--- a/frontend/src/routes/recipes/[id]/+page.js
+++ b/frontend/src/routes/recipes/[id]/+page.js
@@ -1,6 +1,8 @@
+import api from '$lib/api'
+
 export async function load({ fetch, params }) {
   const base = 'http://127.0.0.1:8000/recipes';
-  const recipe = (await fetch(`${base}/${params.id}`)).json();
+  const recipe = await api.recipes.get(params.id);
   const ingredients = (await fetch(`${base}/${params.id}/ingredients`)).json();
   const comments = (await fetch(`${base}/${params.id}/comments`)).json();
   return {

--- a/frontend/src/routes/recipes/[id]/+page.js
+++ b/frontend/src/routes/recipes/[id]/+page.js
@@ -1,10 +1,9 @@
 import api from '$lib/api'
 
 export async function load({ fetch, params }) {
-  const base = 'http://127.0.0.1:8000/recipes';
   const recipe = await api.recipes.get(params.id);
-  const ingredients = (await fetch(`${base}/${params.id}/ingredients`)).json();
-  const comments = (await fetch(`${base}/${params.id}/comments`)).json();
+  const ingredients = await api.recipes.ingredients.get(params.id);
+  const comments = await api.recipes.comments.get(params.id);
   return {
     recipe,
     ingredients,

--- a/frontend/src/routes/recipes/[id]/+page.svelte
+++ b/frontend/src/routes/recipes/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import api from '$lib/api'
   import recipes from '$lib/stores/recipes';
   import Checkable from './Checkable.svelte';
   import Tag from '../Tag.svelte';
@@ -15,9 +16,7 @@
       //delete recipe ingredients
       await Promise.all(
         data.ingredients.map((i) =>
-          fetch(`http://127.0.0.1:8000/recipe_ingredients/${data.recipe.id}:${i.ingredient_id}`, {
-            method: 'DELETE',
-          }),
+          api.recipe_ingredients.remove(data.recipe.id, i.ingredient_id)
         ),
       );
       //delete recipe

--- a/frontend/src/routes/recipes/[id]/+page.svelte
+++ b/frontend/src/routes/recipes/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { redirect } from '@sveltejs/kit';
+  import recipes from '$lib/stores/recipes';
   import Checkable from './Checkable.svelte';
   import Tag from '../Tag.svelte';
   import CommentSection from './CommentSection.svelte';
@@ -21,7 +21,7 @@
         ),
       );
       //delete recipe
-      await fetch(`http://127.0.0.1:8000/recipes/${data.recipe.id}`, { method: 'DELETE' });
+      recipes.remove(data.recipe.id);
     }
   };
 </script>

--- a/frontend/src/routes/recipes/[id]/edit/+page.js
+++ b/frontend/src/routes/recipes/[id]/edit/+page.js
@@ -2,9 +2,7 @@ import api from '$lib/api'
 
 export async function load({ params, fetch }) {
   const recipe = await api.recipes.get(params.id);
-  const ingredients_data = await (
-    await fetch(`http://127.0.0.1:8000/recipes/${params.id}/ingredients`)
-  ).json();
+  const ingredients_data = await api.recipes.ingredients.get(params.id);
 
   const ingredients = ingredients_data
     .map((i) => ({

--- a/frontend/src/routes/recipes/[id]/edit/+page.js
+++ b/frontend/src/routes/recipes/[id]/edit/+page.js
@@ -1,5 +1,7 @@
+import api from '$lib/api'
+
 export async function load({ params, fetch }) {
-  const recipe = await (await fetch(`http://127.0.0.1:8000/recipes/${params.id}`)).json();
+  const recipe = await api.recipes.get(params.id);
   const ingredients_data = await (
     await fetch(`http://127.0.0.1:8000/recipes/${params.id}/ingredients`)
   ).json();

--- a/frontend/src/routes/recipes/[id]/edit/+page.svelte
+++ b/frontend/src/routes/recipes/[id]/edit/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import api from '$lib/api'
   import recipes from '$lib/stores/recipes';
   import ingredients from '$lib/stores/ingredients';
   import RecipeForm from '$lib/components/RecipeForm.svelte';
@@ -36,11 +37,7 @@
           ingredient_id: $ingredients.find((i) => i.name === name).id,
         };
 
-        fetch(`http://127.0.0.1:8000/recipes/${data.recipe.id}/ingredients`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(obj),
-        });
+        api.recipes.ingredients.add(data.recipe.id, obj)
       });
 
     //put rest

--- a/frontend/src/routes/recipes/[id]/edit/+page.svelte
+++ b/frontend/src/routes/recipes/[id]/edit/+page.svelte
@@ -2,7 +2,6 @@
   import recipes from '$lib/stores/recipes';
   import ingredients from '$lib/stores/ingredients';
   import RecipeForm from '$lib/components/RecipeForm.svelte';
-  import { append } from 'svelte/internal';
   export let data;
 
   let current_ingredients = data.ingredients;

--- a/frontend/src/routes/recipes/[id]/edit/+page.svelte
+++ b/frontend/src/routes/recipes/[id]/edit/+page.svelte
@@ -17,9 +17,7 @@
       .map((ri) => $ingredients.find((i) => i.name === ri.name));
     await Promise.all(
       deleted.map((i) => {
-        fetch(`http://127.0.0.1:8000/recipe_ingredients/${data.recipe.id}:${i.id}`, {
-          method: 'DELETE',
-        });
+        api.recipe_ingredients.remove(data.recipe.id, i.id);
       }),
     );
 
@@ -42,20 +40,15 @@
 
     //put rest
     const rest = data.ingredients.filter((ri) => !missing.map((m) => m.name).includes(ri.name));
-    rest.map(({ name, ...ri }) => {
-      const obj = {
-        ...ri,
-        recipe_id: data.recipe.id,
-        ingredient_id: $ingredients.find((i) => i.name === name).id,
-      };
-
-      fetch(`http://127.0.0.1:8000/recipe_ingredients/${obj.recipe_id}:${obj.ingredient_id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(obj),
-      });
-    });
-  };
+    api.recipe_ingredients.update_many(
+      rest.map(({ name, ...ri }) => {
+        return {
+          ...ri,
+          recipe_id: data.recipe.id,
+          ingredient_id: $ingredients.find((i) => i.name === name).id,
+      }})
+    )
+  }
 </script>
 
 <h1>Edit {data.recipe.name}</h1>

--- a/frontend/src/routes/recipes/add/+page.svelte
+++ b/frontend/src/routes/recipes/add/+page.svelte
@@ -11,7 +11,7 @@
 
   const submitForm = async () => {
     // create recipe and update state
-    const recipe = await recipes.add({
+    const recipe = await recipes.create({
       name,
       servings,
       method,

--- a/frontend/src/routes/recipes/add/+page.svelte
+++ b/frontend/src/routes/recipes/add/+page.svelte
@@ -1,4 +1,5 @@
 <script>
+  import api from '$lib/api'
   import recipes from '$lib/stores/recipes';
   import ingredients from '$lib/stores/ingredients';
   import RecipeForm from '$lib/components/RecipeForm.svelte';
@@ -37,11 +38,7 @@
         position: ri.position,
       };
 
-      fetch(`http://127.0.0.1:8000/recipes/${recipe.id}/ingredients`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
+      api.recipes.ingredients.add(recipe.id, data)
     });
   };
 </script>


### PR DESCRIPTION
API calls are now centralized into $lib/api.js, which pulls the url from the environment. This makes deploying the app much easier than before.

Unfortunately, this PR introduces a bunch of warnings because api.js utilizes window.fetch. This will probably be fixed in #70 